### PR TITLE
Add support for relative paths

### DIFF
--- a/lib/emit.js
+++ b/lib/emit.js
@@ -1072,19 +1072,27 @@
       return this._pkg = namespace;
     };
 
-    GoEmitter.prototype.emit_imports = function(_arg) {
-      var import_as, imports, line, messages, path, types, _i, _len, _ref;
+    GoEmitter.prototype.emit_imports = function(_arg, outfile, types_only) {
+      var import_as, imports, line, messages, path, prefix, relative_dir, relative_file, types, _i, _len, _ref;
       imports = _arg.imports, messages = _arg.messages, types = _arg.types;
       this.output("import (");
       this.tab();
-      this.output('"github.com/keybase/go-framed-msgpack-rpc/rpc"');
+      if (!types_only) {
+        this.output('"github.com/keybase/go-framed-msgpack-rpc/rpc"');
+      }
       if (Object.keys(messages).length > 0) {
         this.output('context "golang.org/x/net/context"');
       }
+      prefix = process.env.GOPATH + '/src/';
+      relative_file = path_lib.resolve(outfile).replace(prefix, "");
+      relative_dir = path_lib.dirname(relative_file);
       for (_i = 0, _len = imports.length; _i < _len; _i++) {
         _ref = imports[_i], import_as = _ref.import_as, path = _ref.path;
         if (!(path.indexOf('/') >= 0)) {
           continue;
+        }
+        if (path.match(/(\.\/|\.\.\/)/)) {
+          path = path_lib.normalize(relative_dir + "/" + path);
         }
         line = "";
         if (import_as != null) {
@@ -1275,15 +1283,13 @@
     };
 
     GoEmitter.prototype.run = function(_arg) {
-      var infile, json, types_only;
-      infile = _arg.infile, json = _arg.json, types_only = _arg.types_only;
+      var infile, json, outfile, types_only;
+      infile = _arg.infile, outfile = _arg.outfile, json = _arg.json, types_only = _arg.types_only;
       this.emit_preface({
         infile: infile
       });
       this.emit_package(json);
-      if (!types_only) {
-        this.emit_imports(json);
-      }
+      this.emit_imports(json, outfile, types_only);
       this.emit_types(json);
       if (!types_only) {
         this.emit_interface(json);

--- a/lib/main.js
+++ b/lib/main.js
@@ -22,11 +22,12 @@
   };
 
   emit = function(_arg, cb) {
-    var code, e, infile, json, types_only;
-    infile = _arg.infile, json = _arg.json, types_only = _arg.types_only;
+    var code, e, infile, json, outfile, types_only;
+    infile = _arg.infile, outfile = _arg.outfile, json = _arg.json, types_only = _arg.types_only;
     e = new GoEmitter();
     code = e.run({
       infile: infile,
+      outfile: outfile,
       json: json,
       types_only: types_only
     });
@@ -193,6 +194,7 @@
                 });
                 emit({
                   infile: infile,
+                  outfile: outfile,
                   json: ast.to_json(),
                   types_only: _this.types_only
                 }, esc(__iced_deferrals.defer({

--- a/src/main.iced
+++ b/src/main.iced
@@ -22,9 +22,9 @@ Use -t to only print types and ignore function definitions.
 
 #================================================
 
-emit = ( { infile, json, types_only }, cb) ->
+emit = ( { infile, outfile, json, types_only }, cb) ->
   e = new GoEmitter()
-  code = e.run { infile, json, types_only }
+  code = e.run { infile, outfile, json, types_only }
   cb null, code
 
 #================================================
@@ -89,7 +89,7 @@ exports.Main = class Main
       console.log "Deleting #{outfile}" unless err?
     else
       await avdl2json.parse { infile, version : 2 }, esc defer ast
-      await emit { infile, json : ast.to_json(), @types_only }, esc defer code
+      await emit { infile, outfile, json : ast.to_json(), @types_only }, esc defer code
       await output { code, outfile }, esc defer()
       console.log "Compiling #{infile} -> #{outfile}"
     cb null


### PR DESCRIPTION
This allows us to write imports in avdl files like:

```
import idl "../keybase1" as keybase1;
```

Since relative imports in go are considered somewhat unidiomatic, this line will be compiled to:

```go
import (
    keybase1 "github.com/<path/to/my/output/dir>/keybase1"
)
```

Relative imports will allow us to support languages like Python and TypeScript, where the concept of a GOPATH doesn't exist.