### PR TITLE
Python: use dataclasses_json mixin instead of decorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.4.5
+
+- Uses [dataclasses_json](https://github.com/lidatong/dataclasses-json)'s mixin object instead of its `@dataclass_json` decorator for Python type generation, giving better MyPy support.
+
 # 1.4.4
 
 - Add @timeout_msec(xxx) to methods to offer default timeout.

--- a/lib/py_emit.js
+++ b/lib/py_emit.js
@@ -139,7 +139,7 @@
       this.output("from typing import Dict, List, Optional, Union");
       this.output("from typing_extensions import Literal");
       this.output("");
-      this.output("from dataclasses_json import dataclass_json, config");
+      this.output("from dataclasses_json import config, DataClassJsonMixin");
       this.output("");
       imports = uniqWith(imports, isEqual);
       relative_dir = path_lib.dirname(outfile);
@@ -191,9 +191,8 @@
 
     PythonEmitter.prototype.emit_record = function(record) {
       var f, fields, _i, _len;
-      this.output("@dataclass_json");
       this.output("@dataclass");
-      this.output("class " + record.name + ":");
+      this.output("class " + record.name + "(DataClassJsonMixin):");
       this.tab();
       fields = record.fields.sort((function(_this) {
         return function(a, b) {
@@ -270,9 +269,8 @@
                 throw new Error("Unrecognized type");
             }
           }).call(_this);
-          _this.output("@dataclass_json");
           _this.output("@dataclass");
-          _this.output("class " + type.name + "__" + type_case.label.name + ":");
+          _this.output("class " + type.name + "__" + type_case.label.name + "(DataClassJsonMixin):");
           _this.tab();
           _this.output("" + type["switch"].name + ": Literal[" + (is_switch_primitive ? '' : type["switch"].type + 'Strings.') + type_case.label.name + "]");
           _this.output("" + type_case.label.name + ": " + bodyType);

--- a/src/py_emit.iced
+++ b/src/py_emit.iced
@@ -91,7 +91,7 @@ exports.PythonEmitter = class PythonEmitter extends BaseEmitter
     @output "from typing import Dict, List, Optional, Union"
     @output "from typing_extensions import Literal"
     @output ""
-    @output "from dataclasses_json import dataclass_json, config"
+    @output "from dataclasses_json import config, DataClassJsonMixin"
     @output ""
 
     imports = uniqWith imports, isEqual
@@ -127,9 +127,8 @@ exports.PythonEmitter = class PythonEmitter extends BaseEmitter
     Boolean(field.optional)
 
   emit_record : (record) ->
-    @output "@dataclass_json"
     @output "@dataclass"
-    @output "class #{record.name}:"
+    @output "class #{record.name}(DataClassJsonMixin):"
     @tab()
 
     # Python needs all non-optional types to come before optional types so we sort
@@ -182,9 +181,8 @@ exports.PythonEmitter = class PythonEmitter extends BaseEmitter
           when type_case.body.type == 'array' then "Optional[List[#{@emit_primitive_type(type_case.body.items)}]]"
           else
             throw new Error "Unrecognized type"
-        @output "@dataclass_json"
         @output "@dataclass"
-        @output "class #{type.name}__#{type_case.label.name}:"
+        @output "class #{type.name}__#{type_case.label.name}(DataClassJsonMixin):"
         @tab()
         @output "#{type.switch.name}: Literal[#{if is_switch_primitive then '' else type.switch.type + 'Strings.'}#{type_case.label.name}]"
         @output "#{type_case.label.name}: #{bodyType}"

--- a/src/py_emit.test.iced
+++ b/src/py_emit.test.iced
@@ -75,7 +75,7 @@ describe "PythonEmitter", () ->
         from typing import Dict, List, Optional, Union
         from typing_extensions import Literal
 
-        from dataclasses_json import dataclass_json, config
+        from dataclasses_json import config, DataClassJsonMixin
 
         import test.output.dir.gregor1 as gregor1
         import test.output.dir.keybase1 as keybase1\n
@@ -132,9 +132,8 @@ describe "PythonEmitter", () ->
       code = emitter._code.join "\n"
 
       expect(code).toBe("""
-        @dataclass_json
         @dataclass
-        class TestRecord:
+        class TestRecord(DataClassJsonMixin):
             status_description: str = field(metadata=config(field_name='statusDescription'))
             is_valid_thing: bool = field(metadata=config(field_name='isValidThing'))
             long_int: int = field(metadata=config(field_name='longInt'))
@@ -158,9 +157,8 @@ describe "PythonEmitter", () ->
       code = emitter._code.join "\n"
 
       expect(code).toBe("""
-        @dataclass_json
         @dataclass
-        class TestRecord:
+        class TestRecord(DataClassJsonMixin):
             super_cool: MySuperCoolCustomType = field(metadata=config(field_name='superCool'))\n
       """)
       return
@@ -199,9 +197,8 @@ describe "PythonEmitter", () ->
       code = emitter._code.join "\n"
 
       expect(code).toBe("""
-        @dataclass_json
         @dataclass
-        class MsgSender:
+        class MsgSender(DataClassJsonMixin):
             uid: str = field(metadata=config(field_name='uid'))
             device_id: str = field(metadata=config(field_name='device_id'))
             username: Optional[str] = field(default=None, metadata=config(field_name='username'))
@@ -234,9 +231,8 @@ describe "PythonEmitter", () ->
       code = emitter._code.join "\n"
 
       expect(code).toBe("""
-        @dataclass_json
         @dataclass
-        class StellarServerDefinitions:
+        class StellarServerDefinitions(DataClassJsonMixin):
             revision: int = field(metadata=config(field_name='revision'))
             currencies: Dict[str, OutsideCurrencyDefinition] = field(metadata=config(field_name='currencies'))\n
       """)
@@ -343,27 +339,23 @@ describe "PythonEmitter", () ->
       code = emitter._code.join "\n"
 
       expect(code).toBe("""
-        @dataclass_json
         @dataclass
-        class MyVariant__VERSIONHIT:
+        class MyVariant__VERSIONHIT(DataClassJsonMixin):
             rtype: Literal[InboxResTypeStrings.VERSIONHIT]
             VERSIONHIT: None
 
-        @dataclass_json
         @dataclass
-        class MyVariant__FULL:
+        class MyVariant__FULL(DataClassJsonMixin):
             rtype: Literal[InboxResTypeStrings.FULL]
             FULL: Optional[InboxViewFull]
 
-        @dataclass_json
         @dataclass
-        class MyVariant__HELLO:
+        class MyVariant__HELLO(DataClassJsonMixin):
             rtype: Literal[InboxResTypeStrings.HELLO]
             HELLO: Optional[bool]
 
-        @dataclass_json
         @dataclass
-        class MyVariant__DECK:
+        class MyVariant__DECK(DataClassJsonMixin):
             rtype: Literal[InboxResTypeStrings.DECK]
             DECK: Optional[List[int]]
 

--- a/test/files/sample.py
+++ b/test/files/sample.py
@@ -8,16 +8,15 @@ Input files:
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Dict, List, Optional, Union
-from typing_extensions import Literal
 
-from dataclasses_json import dataclass_json, config
+from dataclasses_json import config, dataclass_json
+from typing_extensions import Literal
 
 import github.com.keybase.client.go.protocol.keybase1 as keybase1
 
 Joe = int
-@dataclass_json
 @dataclass
-class R:
+class R(DataClassJsonMixin):
     bar: keybase1.UID = field(metadata=config(field_name='bar'))
     baz: keybase1.UID = field(metadata=config(field_name='baz_j_uid'))
     woop: Optional[str] = field(default=None, metadata=config(field_name='woop'))
@@ -44,59 +43,50 @@ class EnumNoStringStrings(Enum):
     NOSTRING = 'nostring'
 
 
-@dataclass_json
 @dataclass
-class Boozle__BOZO:
+class Boozle__BOZO(DataClassJsonMixin):
     typ: Literal[TypesStrings.BOZO]
     BOZO: Optional[int]
 
-@dataclass_json
 @dataclass
-class Boozle__BIPPY:
+class Boozle__BIPPY(DataClassJsonMixin):
     typ: Literal[TypesStrings.BIPPY]
     BIPPY: Optional[str]
 
-@dataclass_json
 @dataclass
-class Boozle__AGGLE:
+class Boozle__AGGLE(DataClassJsonMixin):
     typ: Literal[TypesStrings.AGGLE]
     AGGLE: Optional[List[int]]
 
-@dataclass_json
 @dataclass
-class Boozle__FLAGGLE:
+class Boozle__FLAGGLE(DataClassJsonMixin):
     typ: Literal[TypesStrings.FLAGGLE]
     FLAGGLE: Optional[List[bool]]
 
 Boozle = Union[Boozle__BOZO, Boozle__BIPPY, Boozle__AGGLE, Boozle__FLAGGLE]
 
-@dataclass_json
 @dataclass
-class Trixie__NONE:
+class Trixie__NONE(DataClassJsonMixin):
     typ: Literal[TypesStrings.NONE]
     NONE: None
 
-@dataclass_json
 @dataclass
-class Trixie__BOZO:
+class Trixie__BOZO(DataClassJsonMixin):
     typ: Literal[TypesStrings.BOZO]
     BOZO: None
 
-@dataclass_json
 @dataclass
-class Trixie__BIPPY:
+class Trixie__BIPPY(DataClassJsonMixin):
     typ: Literal[TypesStrings.BIPPY]
     BIPPY: Optional[int]
 
-@dataclass_json
 @dataclass
-class Trixie__AGGLE:
+class Trixie__AGGLE(DataClassJsonMixin):
     typ: Literal[TypesStrings.AGGLE]
     AGGLE: None
 
-@dataclass_json
 @dataclass
-class Trixie__FLAGGLE:
+class Trixie__FLAGGLE(DataClassJsonMixin):
     typ: Literal[TypesStrings.FLAGGLE]
     FLAGGLE: Optional[EnumNoString]
 

--- a/test/files/sample.py
+++ b/test/files/sample.py
@@ -8,9 +8,9 @@ Input files:
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Dict, List, Optional, Union
-
-from dataclasses_json import config, dataclass_json
 from typing_extensions import Literal
+
+from dataclasses_json import config, DataClassJsonMixin
 
 import github.com.keybase.client.go.protocol.keybase1 as keybase1
 
@@ -92,43 +92,37 @@ class Trixie__FLAGGLE(DataClassJsonMixin):
 
 Trixie = Union[Trixie__NONE, Trixie__BOZO, Trixie__BIPPY, Trixie__AGGLE, Trixie__FLAGGLE]
 
-@dataclass_json
 @dataclass
-class Noozle__1:
+class Noozle__1(DataClassJsonMixin):
     version: Literal[1]
     1: Optional[str]
 
-@dataclass_json
 @dataclass
-class Noozle__2:
+class Noozle__2(DataClassJsonMixin):
     version: Literal[2]
     2: Optional[int]
 
 Noozle = Union[Noozle__1, Noozle__2]
 
-@dataclass_json
 @dataclass
-class Blurp__true:
+class Blurp__true(DataClassJsonMixin):
     b: Literal[true]
     true: Optional[str]
 
-@dataclass_json
 @dataclass
-class Blurp__false:
+class Blurp__false(DataClassJsonMixin):
     b: Literal[false]
     false: Optional[int]
 
 Blurp = Union[Blurp__true, Blurp__false]
 
-@dataclass_json
 @dataclass
-class Simple:
+class Simple(DataClassJsonMixin):
     s: Optional[Blurp] = field(default=None, metadata=config(field_name='s'))
 
 Hash = str
-@dataclass_json
 @dataclass
-class Cat:
+class Cat(DataClassJsonMixin):
     bird: Dict[str, Noozle] = field(metadata=config(field_name='bird'))
     bee: Dict[str, Noozle] = field(metadata=config(field_name='bee'))
     birds: Dict[str, Optional[List[Noozle]]] = field(metadata=config(field_name='birds'))
@@ -161,15 +155,13 @@ class TeamInviteCategoryStrings(Enum):
     PHONE = 'phone'
 
 
-@dataclass_json
 @dataclass
-class TeamInviteType__UNKNOWN:
+class TeamInviteType__UNKNOWN(DataClassJsonMixin):
     c: Literal[TeamInviteCategoryStrings.UNKNOWN]
     UNKNOWN: Optional[str]
 
-@dataclass_json
 @dataclass
-class TeamInviteType__SBS:
+class TeamInviteType__SBS(DataClassJsonMixin):
     c: Literal[TeamInviteCategoryStrings.SBS]
     SBS: Optional[int]
 


### PR DESCRIPTION
Mypy is bad at detecting types from decorators (see lidatong/dataclasses-json#23), so the mixin will give us the typing support we want. 