### PR TITLE
Go: enum String method emits int for unrecognized names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.4.6
+
+- Go Enum String() method emits integer instead of empty string for unrecognized names
+
 # 1.4.5
 
 - Uses [dataclasses_json](https://github.com/lidatong/dataclasses-json)'s mixin object instead of its `@dataclass_json` decorator for Python type generation, giving better MyPy support.

--- a/lib/go_emit.js
+++ b/lib/go_emit.js
@@ -893,6 +893,19 @@
       return ret;
     };
 
+    GoEmitter.prototype.count_enums_with_string = function(_arg) {
+      var ret, type, types, _i, _len;
+      types = _arg.types;
+      ret = 0;
+      for (_i = 0, _len = types.length; _i < _len; _i++) {
+        type = types[_i];
+        if (type.type === "enum" && type.go !== "nostring") {
+          ret++;
+        }
+      }
+      return ret;
+    };
+
     GoEmitter.prototype.emit_type = function(_arg) {
       var go_field_suffix, nostring, type;
       type = _arg.type, go_field_suffix = _arg.go_field_suffix;
@@ -966,7 +979,7 @@
         this.output("return v");
         this.untab();
         this.output("}");
-        this.output("return \"\"");
+        this.output("return fmt.Sprintf(\"%v\", int(e))");
         this.untab();
         return this.output("}");
       }
@@ -1091,6 +1104,11 @@
         types: types
       }) > 0) {
         this.output('"errors"');
+      }
+      if (this.count_enums_with_string({
+        types: types
+      }) > 0) {
+        this.output('"fmt"');
       }
       if (Object.keys(messages).length > 0) {
         this.output('"time"');

--- a/src/go_emit.iced
+++ b/src/go_emit.iced
@@ -471,6 +471,12 @@ exports.GoEmitter = class GoEmitter extends BaseEmitter
       ret++
     return ret
 
+  count_enums_with_string : ({types}) ->
+    ret = 0
+    for type in types when type.type is "enum" and type.go isnt "nostring"
+      ret++
+    return ret
+
   emit_type : ({type, go_field_suffix}) ->
     @output_doc type.doc
     switch type.type
@@ -529,7 +535,7 @@ exports.GoEmitter = class GoEmitter extends BaseEmitter
       @output "return v"
       @untab()
       @output "}"
-      @output "return \"\""
+      @output "return fmt.Sprintf(\"%v\", int(e))"
       @untab()
       @output "}"
 
@@ -594,6 +600,8 @@ exports.GoEmitter = class GoEmitter extends BaseEmitter
       @output line
     if @count_variants({types}) > 0
       @output '"errors"'
+    if @count_enums_with_string({types}) > 0
+      @output '"fmt"'
     if Object.keys(messages).length > 0
       @output '"time"'
     @untab()

--- a/src/go_emit.test.iced
+++ b/src/go_emit.test.iced
@@ -408,7 +408,7 @@ describe "GoEmitter", () ->
         \tif v, ok := AuditVersionRevMap[e]; ok {
         \t\treturn v
         \t}
-        \treturn ""
+        \treturn fmt.Sprintf("%v", int(e))
         }\n
       """)
       return

--- a/test/files/sample.go
+++ b/test/files/sample.go
@@ -8,6 +8,7 @@ import (
 	context "golang.org/x/net/context"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"errors"
+	"fmt"
 	"time"
 )
 
@@ -63,7 +64,7 @@ func (e Types) String() string {
 	if v, ok := TypesRevMap[e]; ok {
 		return v
 	}
-	return ""
+	return fmt.Sprintf("%v", int(e))
 }
 
 type EnumNoString int
@@ -733,7 +734,7 @@ func (e TeamInviteCategory) String() string {
 	if v, ok := TeamInviteCategoryRevMap[e]; ok {
 		return v
 	}
-	return ""
+	return fmt.Sprintf("%v", int(e))
 }
 
 type TeamInviteType struct {


### PR DESCRIPTION
Something is better than nothing.
```
log.Debug("PresentMessageUnboxed: unhandled MessageUnboxedState: %v", state)
PresentMessageUnboxed: unhandled MessageUnboxedState: '8'
whereas previously it showed:
PresentMessageUnboxed: unhandled MessageUnboxedState: ''
recognized ones are still:
PresentMessageUnboxed: unhandled MessageUnboxedState: 'TEXT'
```