### PR TITLE
Add prepublish script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "avdl-compiler",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "lib/main.js",
   "scripts": {
     "test": "make test",
-    "test:unit": "jest"
+    "test:unit": "jest",
+    "prepublish": "make test"
   },
   "bin": {
     "avdlc": "bin/main.js"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "make test",
     "test:unit": "jest",
-    "prepublish": "make test"
+    "prepublishOnly": "make test"
   },
   "bin": {
     "avdlc": "bin/main.js"

--- a/test/files/sample.go
+++ b/test/files/sample.go
@@ -1,4 +1,4 @@
-// Auto-generated to Go types and interfaces using avdl-compiler v1.4.5 (https://github.com/keybase/node-avdl-compiler)
+// Auto-generated to Go types and interfaces using avdl-compiler v1.4.6 (https://github.com/keybase/node-avdl-compiler)
 //   Input file: avdl/sample.avdl
 
 package sample1

--- a/test/files/sample.py
+++ b/test/files/sample.py
@@ -1,6 +1,6 @@
 """sample.1
 
-Auto-generated to Python types by avdl-compiler v1.4.5 (https://github.com/keybase/node-avdl-compiler)
+Auto-generated to Python types by avdl-compiler v1.4.6 (https://github.com/keybase/node-avdl-compiler)
 Input files:
  - avdl/sample.avdl
 """

--- a/test/files/sample.ts
+++ b/test/files/sample.ts
@@ -2,7 +2,7 @@
  * sample.1
  * SampleInterface protocol is a sample among samples.
  *
- * Auto-generated to TypeScript types by avdl-compiler v1.4.5 (https://github.com/keybase/node-avdl-compiler)
+ * Auto-generated to TypeScript types by avdl-compiler v1.4.6 (https://github.com/keybase/node-avdl-compiler)
  * Input files:
  * - avdl/sample.avdl
  */


### PR DESCRIPTION
Automatically runs `make test` when `npm publish` is run. This should hopefully help fix the travis issues we get when bumping new versions.